### PR TITLE
Add fix for messages build order

### DIFF
--- a/novatel_gps_driver/CMakeLists.txt
+++ b/novatel_gps_driver/CMakeLists.txt
@@ -67,6 +67,9 @@ add_library(${PROJECT_NAME}
   src/parsers/time.cpp
   src/parsers/trackstat.cpp
 )
+
+add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
+
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
   ${Boost_LIBRARIES}


### PR DESCRIPTION
When catkin_make is used to build this package instead of catkin_tools the novatel_gps_driver will build before the novatel_gps_msgs package this leads to a build error see https://github.com/swri-robotics/novatel_gps_driver/issues/34

This adds the catkin dependencies to the cmake file which will resolve this issue. 