### PR TITLE
Add launch file for full driver

### DIFF
--- a/novatel_gps_driver/launch/novatel_gps_driver_eth.launch
+++ b/novatel_gps_driver/launch/novatel_gps_driver_eth.launch
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<!--
+  Copyright (C) 2018-2019 LEIDOS.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+
+-->
+<launch>
+  <arg name="verbose" default="false" doc="Enable verbose output" />
+  <arg name="ip" default="192.168.74.10" doc="The IP of the gps" />
+  <arg name="port" default="2000" doc="The port to use" />
+  <arg name="imu_rate" default="100" doc="The rate at which to publish imu data in Hz" />
+  <arg name="polling_period" default="0.05" doc="The period between gps data publishes in seconds" />
+  <arg name="frame_id" default="gps" doc="The frame of the gps data" />
+  <arg name="imu_frame_id" default="imu" doc="The frame of the imu data" />
+
+  <node name="novatel_gnss_imu"
+        pkg="nodelet" type="nodelet"
+        args="standalone novatel_gps_driver/novatel_gps_nodelet"
+  />
+
+    <param name="verbose" value="$(arg verbose)" />
+    <param name="device" value="$(arg ip):$(arg port)" />
+    <param name="port" value="$(arg port)" />
+    <param name="imu_rate" value="$(arg imu_rate)" />
+    <param name="polling_period" value="$(arg polling_period)" />
+    <param name="frame_id" value="$(arg frame_id)" />
+    <param name="imu_frame_id" value="$(arg imu_frame_id)" />
+    <rosparam>
+      connection_type: tcp
+      imu_sample_rate: -1
+      use_binary_messages: true
+      publish_novatel_positions: true
+      publish_imu_messages: true
+      publish_imu: true
+      publish_novatel_velocity: true
+      publish_nmea_messages: true
+    </rosparam>
+  </node>
+</launch>

--- a/novatel_gps_driver/launch/novatel_gps_driver_eth.launch
+++ b/novatel_gps_driver/launch/novatel_gps_driver_eth.launch
@@ -26,8 +26,7 @@
 
   <node name="novatel_gnss_imu"
         pkg="nodelet" type="nodelet"
-        args="standalone novatel_gps_driver/novatel_gps_nodelet"
-  />
+        args="standalone novatel_gps_driver/novatel_gps_nodelet" >
 
     <param name="verbose" value="$(arg verbose)" />
     <param name="device" value="$(arg ip):$(arg port)" />


### PR DESCRIPTION
This adds a lexus ready launch file to the repo for launching the carma3 compatible driver. 
The launch file is based off the one provided by AStuff on the vehicle PC. 