### PR TITLE
Add node name to status message

### DIFF
--- a/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
+++ b/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
@@ -404,6 +404,7 @@ namespace novatel_gps_driver
       {  // Set driver type
           status_.gnss=true;
           status_.imu=true;
+          status_.name = ros::this_node::getName();
 
           time_difference_=ros::Time::now()-last_update_time_;
 


### PR DESCRIPTION
The name field in the driver status message was not populated. Now it is using the same approach as driver utils.