### PR TITLE
Add dual antenna heading messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ enabled.
             - Default: `false`
         - `publish_novatel_utm_positions`: `true` to publish novatel_gps_msgs/NovatelUtmPosition messages.
             - Default: `false`
+        - `publish_novatel_xyz_positions`: `true` to publish novatel_gps_msgs/NovatelXYZ messages.
+            - Default: `false`
+        - `publish_novatel_heading2`: `true` to publish novatel_gps_msgs/NovatelHeading2 messages.
+            - Default: `false`
+        - `publish_novatel_dual_antenna_heading`: `true` to publish novatel_gps_msgs/NovatelDualAntennaHeading messages.
+            - Default: `false`
         - `publish_novatel_velocity`: `true` to publish novatel_gps_msgs/NovatelVelocity messages.
             - Default: `false`
         - `publish_range_messages`: `true` to publish novatel_gps_msgs/Range messages.
@@ -159,6 +165,9 @@ enabled.
         - `/bestutm` *(novatel_gps_msgs/NovatelUtmPosition)*: [BESTUTM](http://docs.novatel.com/OEM7/Content/Logs/BESTUTM.htm) logs
         - `/bestvel` *(novatel_gps_msgs/NovatelVelocity)*: [BESTVEL](http://docs.novatel.com/OEM7/Content/Logs/BESTVEL.htm) logs
         - `/clocksteering` *(novatel_gps_msgs/ClockSteering)*: [CLOCKSTEERING](http://docs.novatel.com/OEM7/Content/Logs/CLOCKSTEERING.htm) logs
+        - `/bestxyz` *(novatel_gps_msgs/NovatelXYZ)*: [BESTXYZ](http://docs.novatel.com/OEM7/Content/Logs/BESTXYZ.htm) logs
+        - `/heading2` *(novatel_gps_msgs/NovatelHeadin2)*: [HEADING2](http://docs.novatel.com/OEM7/Content/Logs/HEADING2.htm) logs
+        - `/dual_antenna_heading` *(novatel_gps_msgs/NovatelDualAntennaHeading)*: [DUALANTENNAHEADING](http://docs.novatel.com/OEM7/Content/Logs/DUALANTENNAHEADING.htm) logs
         - `/corrimudata` *(novatel_gps_msgs/NovatelCorrectedImuData)*: [CORRIMUDATA](http://docs.novatel.com/OEM7/Content/SPAN_Logs/CORRIMUDATA.htm) logs
         - `/diagnostics` *(diagnostic_msgs/DiagnosticArray)*: ROS diagnostics
         - `/gpgga` *(novatel_gps_msgs/Gpgga)*: [GPGGA](http://docs.novatel.com/OEM7/Content/Logs/GPGGA.htm) logs

--- a/novatel_gps_driver/CMakeLists.txt
+++ b/novatel_gps_driver/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(${PROJECT_NAME}
   src/parsers/gprmc.cpp
   src/parsers/header.cpp
   src/parsers/heading2.cpp
+  src/parsers/dual_antenna_heading.cpp
   src/parsers/inscov.cpp
   src/parsers/inspva.cpp
   src/parsers/inspvax.cpp

--- a/novatel_gps_driver/include/novatel_gps_driver/novatel_gps.h
+++ b/novatel_gps_driver/include/novatel_gps_driver/novatel_gps.h
@@ -71,6 +71,7 @@
 #include <novatel_gps_driver/parsers/gpgsv.h>
 #include <novatel_gps_driver/parsers/gprmc.h>
 #include <novatel_gps_driver/parsers/heading2.h>
+#include <novatel_gps_driver/parsers/dual_antenna_heading.h>
 #include <novatel_gps_driver/parsers/inspva.h>
 #include <novatel_gps_driver/parsers/insstdev.h>
 #include <novatel_gps_driver/parsers/range.h>
@@ -170,6 +171,12 @@ namespace novatel_gps_driver
        * @param[out] headings New HEADING2 messages.
        */
       void GetNovatelHeading2Messages(std::vector<novatel_gps_msgs::NovatelHeading2Ptr>& headings);
+      /**
+       * @brief Provides any DUALANTENNAHEADING messages that have been received since the
+       * last time this was called.
+       * @param[out] headings New DUALANTENNAHEADING messages.
+       */
+      void GetNovatelDualAntennaHeadingMessages(std::vector<novatel_gps_msgs::NovatelDualAntennaHeadingPtr>& headings);
       /**
        * @brief Provides any Imu messages that have been generated since the
        * last time this was called.
@@ -451,6 +458,7 @@ namespace novatel_gps_driver
       BestutmParser bestutm_parser_;
       BestvelParser bestvel_parser_;
       Heading2Parser heading2_parser_;
+      DualAntennaHeadingParser dual_antenna_heading_parser_;
       ClockSteeringParser clocksteering_parser_;
       CorrImuDataParser corrimudata_parser_;
       GpggaParser gpgga_parser_;
@@ -483,6 +491,7 @@ namespace novatel_gps_driver
       boost::circular_buffer<novatel_gps_msgs::NovatelVelocityPtr> novatel_velocities_;
       boost::circular_buffer<novatel_gps_msgs::NovatelPositionPtr> position_sync_buffer_;
       boost::circular_buffer<novatel_gps_msgs::NovatelHeading2Ptr> heading2_msgs_;
+      boost::circular_buffer<novatel_gps_msgs::NovatelDualAntennaHeadingPtr> dual_antenna_heading_msgs_;
       boost::circular_buffer<novatel_gps_msgs::RangePtr> range_msgs_;
       boost::circular_buffer<novatel_gps_msgs::TimePtr> time_msgs_;
       boost::circular_buffer<novatel_gps_msgs::TrackstatPtr> trackstat_msgs_;

--- a/novatel_gps_driver/include/novatel_gps_driver/parsers/dual_antenna_heading.h
+++ b/novatel_gps_driver/include/novatel_gps_driver/parsers/dual_antenna_heading.h
@@ -1,0 +1,68 @@
+// *****************************************************************************
+//
+// Copyright (c) 2017, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL SOUTHWEST RESEARCH INSTITUTE BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#ifndef NOVATEL_GPS_DRIVER_DUAL_ANTENNA_HEADING_H
+#define NOVATEL_GPS_DRIVER_DUAL_ANTENNA_HEADING_H
+
+#include <novatel_gps_msgs/NovatelDualAntennaHeading.h>
+
+#include <novatel_gps_driver/parsers/parsing_utils.h>
+#include <novatel_gps_driver/parsers/message_parser.h>
+
+namespace novatel_gps_driver
+{
+  class DualAntennaHeadingParser : public MessageParser<novatel_gps_msgs::NovatelDualAntennaHeadingPtr>
+  {
+  public:
+    uint32_t GetMessageId() const override;
+
+    const std::string GetMessageName() const override;
+
+    novatel_gps_msgs::NovatelDualAntennaHeadingPtr ParseBinary(const BinaryMessage& bin_msg) throw(ParseException) override;
+
+    novatel_gps_msgs::NovatelDualAntennaHeadingPtr ParseAscii(const NovatelSentence& sentence) throw(ParseException) override;
+
+    static constexpr uint16_t MESSAGE_ID = 2042;
+    static constexpr size_t BINARY_LENGTH = 44;
+    static constexpr size_t ASCII_LENGTH = 17;
+    static const std::string MESSAGE_NAME;
+
+  private:
+    /*
+     * @brief Converts a Solution Source byte mask to the format used in the NovatelDualAntennaHeading ros message
+     *
+     * ParseException thrown if source_mask cannot be parsed
+     * @param[in] source_mask The byte to parse
+     * @return NovatelDualAntennaHeading.solution_source enum value
+     */
+    uint8_t SolutionSourceToMsgEnum(uint8_t source_mask) throw(ParseException);
+  };
+}
+
+#endif //NOVATEL_GPS_DRIVER_DUAL_ANTENNA_HEADING_H

--- a/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
+++ b/novatel_gps_driver/src/nodelets/novatel_gps_nodelet.cpp
@@ -150,6 +150,7 @@
 #include <novatel_gps_msgs/NovatelUtmPosition.h>
 #include <novatel_gps_msgs/NovatelVelocity.h>
 #include <novatel_gps_msgs/NovatelHeading2.h>
+#include <novatel_gps_msgs/NovatelDualAntennaHeading.h>
 #include <novatel_gps_msgs/Gpgga.h>
 #include <novatel_gps_msgs/Gprmc.h>
 #include <novatel_gps_msgs/Range.h>
@@ -185,6 +186,7 @@ namespace novatel_gps_driver
       publish_novatel_utm_positions_(false),
       publish_novatel_velocity_(false),
       publish_novatel_heading2_(false),
+      publish_novatel_dual_antenna_heading_(false),
       publish_nmea_messages_(false),
       publish_range_messages_(false),
       publish_time_messages_(false),
@@ -237,6 +239,7 @@ namespace novatel_gps_driver
       swri::param(priv, "publish_novatel_utm_positions", publish_novatel_utm_positions_, publish_novatel_utm_positions_);
       swri::param(priv, "publish_novatel_velocity", publish_novatel_velocity_, publish_novatel_velocity_);
       swri::param(priv, "publish_novatel_heading2", publish_novatel_heading2_, publish_novatel_heading2_);
+      swri::param(priv, "publish_novatel_dual_antenna_heading", publish_novatel_dual_antenna_heading_, publish_novatel_dual_antenna_heading_);
       swri::param(priv, "publish_nmea_messages", publish_nmea_messages_, publish_nmea_messages_);
       swri::param(priv, "publish_range_messages", publish_range_messages_, publish_range_messages_);
       swri::param(priv, "publish_time_messages", publish_time_messages_, publish_time_messages_);
@@ -322,6 +325,11 @@ namespace novatel_gps_driver
       if (publish_novatel_heading2_)
       {
         novatel_heading2_pub_ = swri::advertise<novatel_gps_msgs::NovatelHeading2>(node, "heading2", 100);
+      }
+
+      if (publish_novatel_dual_antenna_heading_)
+      {
+        novatel_dual_antenna_heading_pub_ = swri::advertise<novatel_gps_msgs::NovatelDualAntennaHeading>(node, "dual_antenna_heading", 100);
       }
 
       if (publish_range_messages_)
@@ -412,6 +420,10 @@ namespace novatel_gps_driver
       if (publish_novatel_heading2_)
       {
         opts["heading2" + format_suffix] = polling_period_;
+      }
+      if (publish_novatel_dual_antenna_heading_)
+      {
+        opts["dual_antenna_heading" + format_suffix] = polling_period_;
       }
       if (publish_gpgsa_)
       {
@@ -550,6 +562,7 @@ namespace novatel_gps_driver
     bool publish_novatel_utm_positions_;
     bool publish_novatel_velocity_;
     bool publish_novatel_heading2_;
+    bool publish_novatel_dual_antenna_heading_;
     bool publish_nmea_messages_;
     bool publish_range_messages_;
     bool publish_time_messages_;
@@ -572,6 +585,7 @@ namespace novatel_gps_driver
     ros::Publisher novatel_utm_pub_;
     ros::Publisher novatel_velocity_pub_;
     ros::Publisher novatel_heading2_pub_;
+    ros::Publisher novatel_dual_antenna_heading_pub_;
     ros::Publisher gpgga_pub_;
     ros::Publisher gpgsv_pub_;
     ros::Publisher gpgsa_pub_;
@@ -660,6 +674,7 @@ namespace novatel_gps_driver
       std::vector<novatel_gps_msgs::NovatelXYZPtr> xyz_position_msgs;
       std::vector<novatel_gps_msgs::NovatelUtmPositionPtr> utm_msgs;
       std::vector<novatel_gps_msgs::NovatelHeading2Ptr> heading2_msgs;
+      std::vector<novatel_gps_msgs::NovatelDualAntennaHeadingPtr> dual_antenna_heading_msgs;
       std::vector<gps_common::GPSFixPtr> fix_msgs;
       std::vector<novatel_gps_msgs::GpggaPtr> gpgga_msgs;
       std::vector<novatel_gps_msgs::GprmcPtr> gprmc_msgs;
@@ -705,6 +720,7 @@ namespace novatel_gps_driver
       gps_.GetNovatelUtmPositions(utm_msgs);
       gps_.GetFixMessages(fix_msgs);
       gps_.GetNovatelHeading2Messages(heading2_msgs);
+      gps_.GetNovatelDualAntennaHeadingMessages(dual_antenna_heading_msgs);
 
       // Increment the measurement count by the number of messages we just
       // read
@@ -826,6 +842,16 @@ namespace novatel_gps_driver
           msg->header.stamp += sync_offset;
           msg->header.frame_id = frame_id_;
           novatel_heading2_pub_.publish(msg);
+        }
+      }
+
+      if (publish_novatel_dual_antenna_heading_)
+      {
+        for (const auto& msg : dual_antenna_heading_msgs)
+        {
+          msg->header.stamp += sync_offset;
+          msg->header.frame_id = frame_id_;
+          novatel_dual_antenna_heading_pub_.publish(msg);
         }
       }
 

--- a/novatel_gps_driver/src/novatel_gps.cpp
+++ b/novatel_gps_driver/src/novatel_gps.cpp
@@ -65,6 +65,7 @@ namespace novatel_gps_driver
       inspva_msgs_(MAX_BUFFER_SIZE),
       insstdev_msgs_(MAX_BUFFER_SIZE),
       heading2_msgs_(MAX_BUFFER_SIZE),
+      dual_antenna_heading_msgs_(MAX_BUFFER_SIZE),
       novatel_positions_(MAX_BUFFER_SIZE),
       novatel_xyz_positions_(MAX_BUFFER_SIZE),
       novatel_utm_positions_(MAX_BUFFER_SIZE),
@@ -462,6 +463,12 @@ namespace novatel_gps_driver
     headings.clear();
     headings.insert(headings.end(), heading2_msgs_.begin(), heading2_msgs_.end());
     heading2_msgs_.clear();
+  }
+
+  void  NovatelGps::GetNovatelDualAntennaHeadingMessages(std::vector<novatel_gps_msgs::NovatelDualAntennaHeadingPtr>& headings) {
+    headings.clear();
+    headings.insert(headings.end(), dual_antenna_heading_msgs_.begin(), dual_antenna_heading_msgs_.end());
+    dual_antenna_heading_msgs_.clear();
   }
 
   void NovatelGps::GetNovatelCorrectedImuData(std::vector<novatel_gps_msgs::NovatelCorrectedImuDataPtr>& imu_messages)
@@ -1059,6 +1066,13 @@ namespace novatel_gps_driver
         heading2_msgs_.push_back(heading);
         break;
       }
+      case DualAntennaHeadingParser::MESSAGE_ID:
+      {
+        novatel_gps_msgs::NovatelDualAntennaHeadingPtr heading = dual_antenna_heading_parser_.ParseBinary(msg);
+        heading->header.stamp = stamp;
+        dual_antenna_heading_msgs_.push_back(heading);
+        break;
+      }
       case CorrImuDataParser::MESSAGE_ID:
       {
         novatel_gps_msgs::NovatelCorrectedImuDataPtr imu = corrimudata_parser_.ParseBinary(msg);
@@ -1237,6 +1251,12 @@ namespace novatel_gps_driver
       novatel_gps_msgs::NovatelHeading2Ptr heading = heading2_parser_.ParseAscii(sentence);
       heading->header.stamp = stamp;
       heading2_msgs_.push_back(heading);
+    }
+    else if (sentence.id == "DUALANTENNAHEADING")
+    {
+      novatel_gps_msgs::NovatelDualAntennaHeadingPtr heading = dual_antenna_heading_parser_.ParseAscii(sentence);
+      heading->header.stamp = stamp;
+      dual_antenna_heading_msgs_.push_back(heading);
     }
     else if (sentence.id == "CORRIMUDATAA")
     {

--- a/novatel_gps_driver/src/parsers/dual_antenna_heading.cpp
+++ b/novatel_gps_driver/src/parsers/dual_antenna_heading.cpp
@@ -1,0 +1,181 @@
+// *****************************************************************************
+//
+// Copyright (c) 2017, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL SOUTHWEST RESEARCH INSTITUTE BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#include <novatel_gps_driver/parsers/dual_antenna_heading.h>
+
+#include <novatel_gps_driver/parsers/header.h>
+
+#include <boost/make_shared.hpp>
+
+namespace novatel_gps_driver
+{
+  const std::string DualAntennaHeadingParser::MESSAGE_NAME = "DUALANTENNAHEADING";
+
+  uint32_t DualAntennaHeadingParser::GetMessageId() const
+  {
+    return MESSAGE_ID;
+  }
+
+  const std::string DualAntennaHeadingParser::GetMessageName() const
+  {
+    return MESSAGE_NAME;
+  }
+
+  novatel_gps_msgs::NovatelDualAntennaHeadingPtr DualAntennaHeadingParser::ParseBinary(const BinaryMessage& bin_msg) throw(ParseException) 
+  {
+    if (bin_msg.data_.size() != BINARY_LENGTH)
+    {
+      std::stringstream error;
+      error << "Unexpected DUALANTENNAHEADING message length: " << bin_msg.data_.size();
+      throw ParseException(error.str());
+    }
+    novatel_gps_msgs::NovatelDualAntennaHeadingPtr ros_msg =
+        boost::make_shared<novatel_gps_msgs::NovatelDualAntennaHeading>();
+    HeaderParser header_parser;
+    ros_msg->novatel_msg_header = header_parser.ParseBinary(bin_msg);
+    ros_msg->novatel_msg_header.message_name = MESSAGE_NAME;
+
+    uint16_t solution_status = ParseUInt16(&bin_msg.data_[0]);
+    if (solution_status > MAX_SOLUTION_STATUS)
+    {
+      std::stringstream error;
+      error << "Unknown solution status: " << solution_status;
+      throw ParseException(error.str());
+    }
+    ros_msg->solution_status = SOLUTION_STATUSES[solution_status];
+    
+    uint16_t pos_type = ParseUInt16(&bin_msg.data_[4]);
+    if (pos_type > MAX_POSITION_TYPE)
+    {
+      std::stringstream error;
+      error << "Unknown position type: " << pos_type;
+      throw ParseException(error.str());
+    }
+    ros_msg->position_type = POSITION_TYPES[pos_type];
+
+    ros_msg->baseline_length = ParseFloat(&bin_msg.data_[8]);
+
+    ros_msg->heading = ParseFloat(&bin_msg.data_[12]);
+    ros_msg->pitch = ParseFloat(&bin_msg.data_[16]);
+
+    // Bytes 20-23 reserved 
+
+    ros_msg->heading_sigma = ParseFloat(&bin_msg.data_[24]);
+    ros_msg->pitch_sigma = ParseFloat(&bin_msg.data_[28]);
+
+    ros_msg->station_id.resize(4);
+    std::copy(&bin_msg.data_[32], &bin_msg.data_[36], &ros_msg->station_id[0]);
+
+    ros_msg->num_satellites_tracked = bin_msg.data_[36];
+    ros_msg->num_satellites_used_in_solution = bin_msg.data_[37];
+    ros_msg->num_satellites_above_elevation_mask_angle = bin_msg.data_[38];
+    ros_msg->num_satellites_above_elevation_mask_angle_l2 = bin_msg.data_[39];
+
+    ros_msg->solution_source = SolutionSourceToMsgEnum(bin_msg.data_[40]);
+
+    GetExtendedSolutionStatusMessage(bin_msg.data_[41],
+                                  ros_msg->extended_solution_status);
+
+    // Byte 42 is reserved
+
+    GetSignalsUsed(bin_msg.data_[43], ros_msg->signal_mask);
+
+    return ros_msg;
+  }
+
+  novatel_gps_msgs::NovatelDualAntennaHeadingPtr DualAntennaHeadingParser::ParseAscii(const NovatelSentence& sentence) throw(ParseException)
+  {
+    novatel_gps_msgs::NovatelDualAntennaHeadingPtr ros_msg =
+        boost::make_shared<novatel_gps_msgs::NovatelDualAntennaHeading>();
+    HeaderParser h_parser;
+    ros_msg->novatel_msg_header = h_parser.ParseAscii(sentence);
+
+    if (sentence.body.size() != ASCII_LENGTH)
+    {
+      std::stringstream error;
+      error << "Unexpected number of DUALANTENNAHEADING message fields: " << sentence.body.size();
+      throw ParseException(error.str());
+    }
+
+    bool valid = true;
+
+    ros_msg->solution_status = sentence.body[0];
+    ros_msg->position_type = sentence.body[1];
+    
+    valid = valid && ParseFloat(sentence.body[2], ros_msg->baseline_length);
+
+    valid = valid && ParseFloat(sentence.body[3], ros_msg->heading);
+    valid = valid && ParseFloat(sentence.body[4], ros_msg->pitch);
+
+    // Skip reserved field
+
+    valid = valid && ParseFloat(sentence.body[6], ros_msg->heading_sigma);
+    valid = valid && ParseFloat(sentence.body[7], ros_msg->pitch_sigma);
+
+    ros_msg->station_id = sentence.body[8];
+
+    valid = valid && ParseUInt8(sentence.body[9], ros_msg->num_satellites_tracked);
+    valid = valid && ParseUInt8(sentence.body[10], ros_msg->num_satellites_used_in_solution);
+    valid = valid && ParseUInt8(sentence.body[11], ros_msg->num_satellites_above_elevation_mask_angle);
+    valid = valid && ParseUInt8(sentence.body[12], ros_msg->num_satellites_above_elevation_mask_angle_l2);
+
+    uint32_t solution_source = 0;
+    valid = valid && ParseUInt32(sentence.body[13], solution_source, 16);
+    ros_msg->solution_source = SolutionSourceToMsgEnum((uint8_t)solution_source);
+
+    uint32_t extended_solution_status = 0;
+    valid = valid && ParseUInt32(sentence.body[14], extended_solution_status, 16);
+    GetExtendedSolutionStatusMessage(
+        extended_solution_status, ros_msg->extended_solution_status);
+
+    // Skip reserved field
+
+    uint32_t signal_mask = 0;
+    valid = valid && ParseUInt32(sentence.body[16], signal_mask, 16);
+    GetSignalsUsed(signal_mask, ros_msg->signal_mask);
+
+    if (!valid)
+    {
+      throw ParseException("Invalid field in DUALANTENNAHEADING message");
+    }
+
+    return ros_msg;
+  }
+
+  uint8_t DualAntennaHeadingParser::SolutionSourceToMsgEnum(uint8_t source_mask) throw(ParseException) {
+    uint8_t source_bits = source_mask & 0b00001100;
+    if (source_mask == 0b0000) {
+      return novatel_gps_msgs::NovatelDualAntennaHeading::SOURCE_PRIMARY_ANTENNA;
+    } else if (source_mask == 0b0100) {
+      return novatel_gps_msgs::NovatelDualAntennaHeading::SOURCE_SECONDARY_ANTENNA;
+    } else {
+      throw ParseException("DUALANTENNAHEADING Solution Source could not be parsed due to unknown source");
+    }
+  }
+};

--- a/novatel_gps_msgs/CMakeLists.txt
+++ b/novatel_gps_msgs/CMakeLists.txt
@@ -27,6 +27,7 @@ add_message_files(DIRECTORY msg FILES
   NovatelCorrectedImuData.msg
   NovatelExtendedSolutionStatus.msg
   NovatelHeading2.msg
+  NovatelDualAntennaHeading.msg
   NovatelMessageHeader.msg
   NovatelPosition.msg
   NovatelUtmPosition.msg

--- a/novatel_gps_msgs/msg/NovatelDualAntennaHeading.msg
+++ b/novatel_gps_msgs/msg/NovatelDualAntennaHeading.msg
@@ -1,0 +1,42 @@
+# Parsed Heading East of North from Novatel receiver. Only ALIGN capable recievers can publish this
+Header header
+
+NovatelMessageHeader novatel_msg_header
+
+# Solution Status
+string solution_status
+string position_type
+
+# Baseline length (m)
+float32 baseline_length
+
+# Heading in degrees [0,360)
+float32 heading
+
+# Pitch in degrees +- 90
+float32 pitch
+
+# Orientation Standard Deviations (deg)
+float32 heading_sigma
+float32 pitch_sigma
+
+# Station ids
+string station_id
+
+# Satellite Usage
+uint8 num_satellites_tracked
+uint8 num_satellites_used_in_solution
+uint8 num_satellites_above_elevation_mask_angle
+uint8 num_satellites_above_elevation_mask_angle_l2
+
+# Enum for solution source
+uint8 solution_source
+
+uint8 SOURCE_PRIMARY_ANTENNA=0
+uint8 SOURCE_SECONDARY_ANTENNA=1
+
+# Extended Solution Status
+NovatelExtendedSolutionStatus extended_solution_status
+
+# Signal Masks
+NovatelSignalMask signal_mask


### PR DESCRIPTION
The NovATel OEM7 specification includes a DUALANTENNAHEADING message which reports the heading of the vehicle relative to north at a faster rate than HEADING2. This PR adds support for this message type by adding a NovatelDualAntennaHeading.msg file and the associated parser (dual_antenna_heading.h/.cpp). The messages are published to the /dual_antenna_heading topic. This was tested on a NovATel PwrPak7.

The DUALANTENNAHEADING message spec
https://docs.novatel.com/OEM7/Content/Logs/DUALANTENNAHEADING.htm