### PR TITLE
Fix dependency linkage in docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,17 +12,19 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 
-FROM usdotfhwastol/carma-base:3.0.0 as setup
+FROM usdotfhwastol/carma-base:latest as deps
 
 RUN sudo apt-get update \
     && sudo apt-get install -y libpcap-dev ros-kinetic-gps-common ros-kinetic-swri-math-util ros-kinetic-swri-roscpp ros-kinetic-swri-serial-util ros-kinetic-swri-string-util ros-kinetic-swri-nodelet
+
+FROM deps as setup
 
 RUN mkdir ~/src
 COPY --chown=carma . /home/carma/src/
 RUN ~/src/docker/checkout.sh
 RUN ~/src/docker/install.sh
 
-FROM usdotfhwastol/carma-base:3.0.0
+FROM deps
 
 ARG BUILD_DATE="NULL"
 ARG VERSION="NULL"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 
-FROM usdotfhwastol/carma-base:latest as deps
+FROM usdotfhwastol/carma-base:3.0.0 as deps
 
 RUN sudo apt-get update \
     && sudo apt-get install -y libpcap-dev ros-kinetic-gps-common ros-kinetic-swri-math-util ros-kinetic-swri-roscpp ros-kinetic-swri-serial-util ros-kinetic-swri-string-util ros-kinetic-swri-nodelet


### PR DESCRIPTION
This docker file has run time dependencies installed at it's build stage that were not available at run time. This Resolves that issue by creating a base deps layer that both the build and install layers depend on. 