### PR TITLE
Update base image version for autoware component release 3.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
     # Pull docker image from docker hub
     # XTERM used for better catkin_make output
     docker:
-      - image: usdotfhwastol/carma-base:3.3.0
+      - image: usdotfhwastol/carma-base:3.4.0
         user: carma
         environment:
           TERM: xterm # use xterm to get full display output from build

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 
-FROM usdotfhwastol/carma-base:3.3.0 as deps
+FROM usdotfhwastol/carma-base:3.4.0 as deps
 
 FROM deps as setup
 


### PR DESCRIPTION
Update base image version for autoware component release 3.4.0
Helps address: usdot-fhwa-stol/CARMAPlatform#419